### PR TITLE
Change ServerTimingRecorder to request scoped rather than singlton

### DIFF
--- a/src/Metalface.AspNetCore.ServerTiming/ServerTimingExtensions.cs
+++ b/src/Metalface.AspNetCore.ServerTiming/ServerTimingExtensions.cs
@@ -13,7 +13,7 @@ namespace Metalface.AspNetCore.ServerTiming
                 throw new System.ArgumentNullException(nameof(services));
             }
 
-            services.TryAdd(ServiceDescriptor.Singleton<IServerTimingRecorder, ServerTimingRecorder>());
+            services.TryAdd(ServiceDescriptor.Scoped<IServerTimingRecorder, ServerTimingRecorder>());
 
             return services;
         }


### PR DESCRIPTION
## What is implemented

Closes #33

Change ServerTimingRecorder to Request scoped otherwise a second request includes the timing of previous request(s).

## How it is implemented

Trivial change.

## How can it be tested

When in use, refresh the page that include the timing.  Only the times of the current request shall be included.

## Todos

Mark if complete or not relevant:  

- [ ] Test: write tests
- [ ] Test: Make sure code coverage hasn't dropped
- [ ] Test: Provide verification config / commands / resources
- [ ] Documentation: write documentation
- [ ] Other: enable "Allow edits from maintainers" for this PR
- [ ] Other: update the messages below

Is it a breaking change?: NO
